### PR TITLE
Refactor AppleScript modules to achieve better separation of concerns.

### DIFF
--- a/Sources/Main.applescript
+++ b/Sources/Main.applescript
@@ -2,18 +2,22 @@
 -- ==========================================
 -- Module Loading
 -- ==========================================
-global Network, WindowManager, ServerManager
+global Network, WindowManager, ServerManager, TerminalManager, CommandBuilder
 
 on loadModules()
 	set script_path to path to me
 	tell application "Finder"
 		set script_container to container of script_path as text
 	end tell
+	-- buildディレクトリ内のコンパイル済みモジュールをロード
 	set compiled_modules_folder to (script_container & "build:modules:")
 
+	-- 全てのモジュールをロードする
 	set Network to load script alias (compiled_modules_folder & "Network.scpt")
 	set WindowManager to load script alias (compiled_modules_folder & "WindowManager.scpt")
 	set ServerManager to load script alias (compiled_modules_folder & "ServerManager.scpt")
+	set TerminalManager to load script alias (compiled_modules_folder & "TerminalManager.scpt")
+	set CommandBuilder to load script alias (compiled_modules_folder & "CommandBuilder.scpt")
 end loadModules
 
 -- ==========================================
@@ -23,11 +27,12 @@ on runWithConfiguration(modelName, ollamaPort, overrideIP)
 	my loadModules()
 	try
 		set ip_to_use to Network's getIPAddress(overrideIP)
-
 		if Network's isPortInUse(ollamaPort, ip_to_use) then
-			my handleExistingServer(ip_to_use, modelName, ollamaPort)
+			log "An existing server process was found on port " & ollamaPort
+			my startChatInExistingServer(ip_to_use, modelName, ollamaPort)
 		else
-			my handleNewServer(ip_to_use, modelName, ollamaPort)
+			log "No existing server process found. Starting a new server."
+			my startNewServerAndChat(ip_to_use, modelName, ollamaPort)
 		end if
 	on error error_message
 		log "Execution Error: An error occurred: " & error_message
@@ -35,27 +40,47 @@ on runWithConfiguration(modelName, ollamaPort, overrideIP)
 end runWithConfiguration
 
 -- ==========================================
--- Internal Flow Control Functions
+-- Internal Flow Control Functions (Orchestration)
 -- ==========================================
-on handleExistingServer(ip_address, modelName, ollamaPort)
+on startChatInExistingServer(ip_address, modelName, ollamaPort)
 	set server_info to WindowManager's findLatestServerWindow(ip_address, ollamaPort)
 	set server_window to server_info's window
 	set sequence_number to server_info's sequence
-	if server_window is not missing value then
-		ServerManager's executeOllamaModel(server_window, ip_address, sequence_number, modelName, ollamaPort, WindowManager)
-	else
-		my handleNewServer(ip_address, modelName, ollamaPort)
-	end if
-end handleExistingServer
 
-on handleNewServer(ip_address, modelName, ollamaPort)
-	set server_info to ServerManager's startOllamaServer(ip_address, ollamaPort, modelName, WindowManager)
-	set server_window to server_info's window
-	set sequence_number to server_info's sequence
+	if server_window is not missing value then
+		my executeModelInWindow(server_window, ip_address, sequence_number, modelName, ollamaPort)
+	else
+		log "Server process found, but no corresponding window. Starting new server flow."
+		my startNewServerAndChat(ip_address, modelName, ollamaPort)
+	end if
+end startChatInExistingServer
+
+on startNewServerAndChat(ip_address, modelName, ollamaPort)
+	-- 1. 各モジュールに問い合わせ、必要な情報を収集・生成
+	set next_seq to (WindowManager's getMaxSequenceNumber(ip_address, ollamaPort) + 1)
+	set server_command to CommandBuilder's buildServerCommand(ip_address, ollamaPort, modelName)
+	set server_title to WindowManager's generateWindowTitle(ip_address, next_seq, "server", ollamaPort, modelName)
+
+	-- 2. TerminalManagerに指示を出し、サーバーを起動
+	set new_server_window to TerminalManager's createNewWindowWithCommand(server_command)
+	TerminalManager's setTitleOf(new_server_window, server_title)
+
+	-- 3. ServerManagerに指示を出し、サーバーの起動を待つ
 	if ServerManager's waitForServer(ip_address, ollamaPort, Network) then
-		delay 1 -- Wait for the server to fully start
-		ServerManager's executeOllamaModel(server_window, ip_address, sequence_number, modelName, ollamaPort, WindowManager)
+		delay 1
+		-- 4. 起動成功後、モデル実行フローへ
+		my executeModelInWindow(new_server_window, ip_address, next_seq, modelName, ollamaPort)
 	else
 		log "Startup Failed: Failed to start the server."
 	end if
-end handleNewServer
+end startNewServerAndChat
+
+on executeModelInWindow(target_window, ip_address, sequence_number, model_name, ollama_port)
+	-- 1. コマンドとタイトルを生成
+	set model_command to CommandBuilder's buildModelCommand(ip_address, ollama_port, model_name)
+	set tab_title to WindowManager's generateWindowTitle(ip_address, sequence_number, "chat", ollama_port, model_name)
+
+	-- 2. TerminalManagerに指示を出し、新しいタブでモデルを実行
+	set new_tab to TerminalManager's openNewTabInWindow(target_window, model_command)
+	TerminalManager's setTitleOf(new_tab, tab_title)
+end executeModelInWindow

--- a/Sources/Modules/CommandBuilder.applescript
+++ b/Sources/Modules/CommandBuilder.applescript
@@ -1,0 +1,18 @@
+-- CommandBuilder.applescript
+-- シェルコマンドの文字列を生成する責務を担うモジュール
+
+on buildServerCommand(ip_address, port, model_name)
+	set display_command to "echo '--- Private LLM Launcher ---'; " & ¬
+		"echo 'IP Address: " & ip_address & "'; " & ¬
+		"echo 'Port: " & port & "'; " & ¬
+		"echo 'Model: " & model_name & "'; " & ¬
+		"echo '--------------------------'; " & ¬
+		"echo 'Starting Ollama server...';"
+
+	set server_command to "OLLAMA_HOST=" & ip_address & ":" & port & " ollama serve"
+	return display_command & " " & server_command
+end buildServerCommand
+
+on buildModelCommand(ip_address, port, model_name)
+	return "OLLAMA_HOST=http://" & ip_address & ":" & port & " ollama run " & model_name
+end buildModelCommand

--- a/Sources/Modules/ServerManager.applescript
+++ b/Sources/Modules/ServerManager.applescript
@@ -1,91 +1,18 @@
--- Properties for local constants
+-- ServerManager.applescript
+-- サーバーが起動するのを待つ責務を担うモジュール
+
 property SERVER_STARTUP_TIMEOUT : 30
 property SERVER_CHECK_INTERVAL : 0.1
 
--- Properties for other modules, inherited from the parent script
 on waitForServer(ip_address, ollama_port, Network)
-        set elapsed to 0
-        repeat until Network's isPortInUse(ollama_port, ip_address)
-            delay SERVER_CHECK_INTERVAL
-            set elapsed to elapsed + SERVER_CHECK_INTERVAL
-            if elapsed > SERVER_STARTUP_TIMEOUT then
-                log "Timeout: Server startup timed out. Please check manually."
-                return false
-            end if
-        end repeat
-        return true
-    end waitForServer
-
-    on openNewTerminalTab(parent_window, command)
-        tell application "Terminal"
-            activate
-            set current_window to parent_window
-            set selected of current_window to true
-            tell application "System Events"
-                keystroke "t" using command down
-            end tell
-            delay 0.5
-            do script command in front window
-            return selected tab of front window
-        end tell
-    end openNewTerminalTab
-
-    on setTerminalTitle(window_or_tab, title)
-        tell application "Terminal"
-            set custom title of window_or_tab to title
-        end tell
-    end setTerminalTitle
-
-    on createNewTerminalWindow(command)
-        tell application "Terminal"
-            activate
-            do script command
-            return front window
-        end tell
-    end createNewTerminalWindow
-
-on startOllamaServer(ip_address, ollama_port, model_name, WindowManager)
-    set next_seq to (WindowManager's getMaxSequenceNumber(ip_address, ollama_port) + 1)
-    set window_title to WindowManager's generateWindowTitle(ip_address, next_seq, "server", ollama_port, model_name)
-
-    set display_command to "echo '--- Private LLM Launcher ---'; " & ¬
-        "echo 'IP Address: " & ip_address & "'; " & ¬
-        "echo 'Port: " & ollama_port & "'; " & ¬
-        "echo 'Model: " & model_name & "'; " & ¬
-        "echo '--------------------------'; " & ¬
-        "echo 'Starting Ollama server...';"
-
-    set server_command to "OLLAMA_HOST=" & ip_address & ":" & ollama_port & " ollama serve"
-    set final_command to display_command & " " & server_command
-
-    set new_window to my createNewTerminalWindow(final_command)
-        my setTerminalTitle(new_window, window_title)
-
-        return {window:new_window, sequence:next_seq}
-    end startOllamaServer
-
-on validateServerWindow(target_window, ip_address, sequence_number, ollama_port, model_name, WindowManager)
-        if target_window is missing value then
-            set msg to "Ollama server window not found."
-        set details to "Search criteria: IP=" & ip_address & ", PORT=" & ollama_port & return & "Expected window name: " & WindowManager's generateWindowTitle(ip_address, sequence_number, "server", ollama_port, model_name)
-
-            tell application "Terminal"
-                set details to details & return & "Current Terminal window list:"
-                repeat with w in windows
-                    set details to details & return & "- " & custom title of w
-                end repeat
-            end tell
-
-            log "Window Error: " & msg & return & details
-            error "Server window not found"
-        end if
-    end validateServerWindow
-
-on executeOllamaModel(target_window, ip_address, sequence_number, model_name, ollama_port, WindowManager)
-    my validateServerWindow(target_window, ip_address, sequence_number, ollama_port, model_name, WindowManager)
-
-    set command to "OLLAMA_HOST=http://" & ip_address & ":" & ollama_port & " ollama run " & model_name
-        set new_tab to my openNewTerminalTab(target_window, command)
-    set tab_title to WindowManager's generateWindowTitle(ip_address, sequence_number, "chat", ollama_port, model_name)
-    my setTerminalTitle(new_tab, tab_title)
-end executeOllamaModel
+	set elapsed to 0
+	repeat until Network's isPortInUse(ollama_port, ip_address)
+		delay SERVER_CHECK_INTERVAL
+		set elapsed to elapsed + SERVER_CHECK_INTERVAL
+		if elapsed > SERVER_STARTUP_TIMEOUT then
+			log "Timeout: Server startup timed out. Please check manually."
+			return false
+		end if
+	end repeat
+	return true
+end waitForServer

--- a/Sources/Modules/TerminalManager.applescript
+++ b/Sources/Modules/TerminalManager.applescript
@@ -1,0 +1,29 @@
+-- TerminalManager.applescript
+-- ターミナルのウィンドウ・タブ操作に特化したモジュール
+
+on createNewWindowWithCommand(command)
+	tell application "Terminal"
+		activate
+		do script command
+		return front window
+	end tell
+end createNewWindowWithCommand
+
+on openNewTabInWindow(target_window, command)
+	tell application "Terminal"
+		activate
+		set selected of target_window to true
+		tell application "System Events"
+			keystroke "t" using command down
+		end tell
+		delay 0.5
+		do script command in front window
+		return selected tab of front window
+	end tell
+end openNewTabInWindow
+
+on setTitleOf(target, title)
+	tell application "Terminal"
+		set custom title of target to title
+	end tell
+end setTitleOf


### PR DESCRIPTION
This change introduces a more modular architecture by separating responsibilities into distinct scripts:

- `Main`: Acts as the central orchestrator for the application flow.
- `CommandBuilder`: A new module responsible for generating shell command strings.
- `TerminalManager`: A new module dedicated to managing Terminal UI operations (windows and tabs).
- `ServerManager`: Refactored to focus solely on waiting for the server process to start.
- `WindowManager`: Manages the state of terminal windows.

This refactoring enhances code independence and maintainability by eliminating direct dependencies between modules and having `Main.applescript` coordinate all interactions.